### PR TITLE
Add library properties to let Arduino IDE see the example code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/example/__vm
 **/example/.vs
 **/VisualStudio/**
+*.vscode

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Sch_LF
+version=1.0.0 
+author=KhalifNovation
+maintainer=KhalifNovation &lt;syed_uthman@yahoo.com&gt; 
+sentence=An Arduino library for Sch_LF
+paragraph=An Open-sourced arduino library for Sch_LF robotic platform
+category=Other
+url=https://github.com/KhalifNovation/Sch_LF
+architectures=*


### PR DESCRIPTION
1. I copied the Sch_LF library into Arduino->libraries folder but,
2. At Arduino IDE, there is no visibility for Sch_LF example code
3. Adding this file able to resolve that issue