### PR TITLE
Update ls detection method

### DIFF
--- a/examples/CalibrateSensor/CalibrateSensor.ino
+++ b/examples/CalibrateSensor/CalibrateSensor.ino
@@ -84,7 +84,14 @@ void loop()
         }
     }
 
-    // Do robot work here..
+    // Print sensor reading in Binary format
+    uint16_t sensorArr = input.LS_ScanBinary();
+    Serial.print("Sensor reading = ");
+    Serial.print("Binary: ");
+    Serial.print( sensorArr, BIN );
+    Serial.print("  |  Decimal: ");
+    Serial.print( sensorArr, DEC );
+    Serial.println();
 }
 
 // initialize Serial

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -198,7 +198,7 @@ bool Sensor::isLS_detected( uint8_t ch )
 
 uint16_t Sensor::getIntData( DataName dname, uint8_t ch )
 {
-	uint16_t val;
+	uint16_t val = 0u;
 	switch( dname )
 	{
 		case PIN:
@@ -219,6 +219,8 @@ uint16_t Sensor::getIntData( DataName dname, uint8_t ch )
 		case THRESSHOLD:
 			val = AN[ch].ThressHold;
 			break;
+		default:
+		break;
 	}
 
 	return val;
@@ -226,7 +228,7 @@ uint16_t Sensor::getIntData( DataName dname, uint8_t ch )
 
 bool Sensor::getBoolData( DataName dname, uint8_t ch )
 {
-	bool val;
+	bool val = false;
 	switch( dname )
 	{
 		case STATE:
@@ -235,6 +237,8 @@ bool Sensor::getBoolData( DataName dname, uint8_t ch )
 		case LAST_STATE:
 			val = AN[ch].LastState;
 			break;
+		default:
+		break;
 	}
 
 	return val;

--- a/src/Sensor.cpp
+++ b/src/Sensor.cpp
@@ -170,9 +170,30 @@ bool Sensor::isJMP_connected()
 	return (!digitalRead( JMP ) == 0 ? true : false );
 }
 
-bool Sensor::isLS_detected(int ch)
+/**
+ * @brief	Check sensor channel detection on LINE area
+ * 
+ * @param	ch, sensor channel
+ * @return	bool, sensor detection status
+*/
+bool Sensor::isLS_detected( uint8_t ch )
 {
-	return digitalRead(AN[ch].Pin);
+	uint16_t sensorVal;
+	uint16_t tolerance = 10u;
+
+	// Get averaged sensor value
+	sensorVal = analogSampleNX( ch );
+
+	// Compare to sensor value within LINE value range
+	if( sensorVal <= (AN[ch].LineVal + tolerance) && 
+		sensorVal >= (AN[ch].LineVal - tolerance) )
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
 }
 
 uint16_t Sensor::getIntData( DataName dname, uint8_t ch )
@@ -228,4 +249,27 @@ bool Sensor::getBoolData( DataName dname, uint8_t ch )
 uint16_t Sensor::LS_RAW( uint8_t ch )
 {
 	return analogRead(AN[ch].Pin);
+}
+
+/**
+ * @brief	Read sensors and yield result in Binary format.
+ * 			use this format to simplify user's code in interpreting
+ * 			sensor reading values.
+ * 
+ * @param	None
+ * @return	sensorVal, sensors detection in binary format
+*/
+uint16_t Sensor::LS_ScanBinary( void )
+{
+	uint16_t sensorVal = 0u;
+
+	for( uint8_t i = 0; i < NUM_SENSORS; i++ )
+	{
+		if( isLS_detected(i) == true )
+		{
+			sensorVal += (uint16_t)(pow(2, i) + 0.5);
+		}
+	}
+
+	return sensorVal;
 }

--- a/src/Sensor.h
+++ b/src/Sensor.h
@@ -65,13 +65,14 @@ class Sensor
 		CalStatus calibrateSensor( CalType calType );
 
 		bool isBTN_press();
-		bool isJMP_connected();	
-		bool isLS_detected(int ch);
+		bool isJMP_connected();
+		bool isLS_detected( uint8_t ch );
 		
 		uint16_t getIntData( DataName dname, uint8_t ch );
 		bool getBoolData( DataName dname, uint8_t ch );
 		
 		uint16_t LS_RAW( uint8_t ch );
+		uint16_t LS_ScanBinary( void );
 
 	private:
 		uint16_t analogSampleNX( uint8_t sensorCh );


### PR DESCRIPTION
1. Add method to read all LS sensors value and give output in Binary-kind format
   Example:
   S0 S1  S2  S3  S4  S5  S6
   if S0 and S1 is detected, the value will be 2^0 + 2^1 = 1+2 --> 3
   using this method, user's will write less code to compare each sensor values
   and able to practice binary style reading.

2. Put LS sensors range for detection confirmation, this to absorb tolerances given from the sensors/ambient light/line track material itself.